### PR TITLE
fix: monaco-editor popup is now displayed above the header

### DIFF
--- a/app/lib/app/SecvisogramPage/View.js
+++ b/app/lib/app/SecvisogramPage/View.js
@@ -1073,7 +1073,7 @@ function View({
                   </div>
                 )}
                 <div
-                  className="row-span-2 relative overflow-auto h-full bg-white"
+                  className="row-span-2 relative h-full bg-white"
                   key={activeTab}
                 >
                   {activeTab === 'EDITOR' ? (


### PR DESCRIPTION
Der Fix hat leider Auswirkungen auf alle Pages.
Testet vor dem approven bitte auf allen Seiten, ob ihr einen overflow bug findet.